### PR TITLE
fix: use pagination.pagerSize

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,4 @@
 languageCode = 'en-us'
-paginate = 100
 timeout = "60s"
 disableKinds = ["RSS"]
 
@@ -12,6 +11,9 @@ title = "GitHub mirror" # FIXME
   owner = "placeholder-owner" # FIXME
   repository = "placeholder-repository" # FIXME
   footer = "This mirror is hosted by PLACEHOLDER."
+
+[pagination]
+  pagerSize = 100
 
 [taxonomies]
   category = "contributor"


### PR DESCRIPTION
instead of deprecated "paginate"

Fixes the following error and closes #5

  ERROR deprecated: site config key paginate was deprecated in Hugo v0.128.0 and subsequently removed. Use pagination.pagerSize instead.