### PR TITLE
fix: use hash.FNV32a instead off crypto.FNV32a

### DIFF
--- a/layouts/partials/render-label.html
+++ b/layouts/partials/render-label.html
@@ -1,3 +1,3 @@
-{{ $hue := mod (crypto.FNV32a .) 360 }}
+{{ $hue := mod (hash.FNV32a .) 360 }}
 
 <span class="text-small p-1 mx-1 fw-light rounded-2" style="font-size: 0.9em; color: hsl({{ $hue }} 80% 90%); border: 1px solid hsl({{ $hue }} 10% 40%);">{{- . -}}</span>


### PR DESCRIPTION
Since crypto.FNV32a is depreacted and removed in recent hugo versions.

Fixes #7 and resolves:

ERROR deprecated: crypto.FNV32a was deprecated in Hugo v0.129.0 and subsequently removed. Use hash.FNV32a.