### PR TITLE
improve: graph of linked issues

### DIFF
--- a/mirror/html/pages.py
+++ b/mirror/html/pages.py
@@ -91,12 +91,14 @@ def render_entry_page(
     data: dict[str, Any],
     config: Config,
     md: MarkdownRenderer,
+    linked: list[EntryMeta] | None = None,
 ) -> str:
     """Render a single issue or PR page."""
+    _linked = linked or []
     if meta.is_pr:
-        content = _render_pull_content(meta, data, config, md)
+        content = _render_pull_content(meta, data, config, md, _linked)
     else:
-        content = _render_issue_content(meta, data, config, md)
+        content = _render_issue_content(meta, data, config, md, _linked)
     return base_page(f"{meta.title} #{meta.number}", content, config)
 
 
@@ -105,6 +107,7 @@ def _render_issue_content(
     data: dict[str, Any],
     config: Config,
     md: MarkdownRenderer,
+    linked: list[EntryMeta],
 ) -> str:
     """Render issue page content (port of partials/render-issue.html)."""
     b = config.base_url
@@ -139,7 +142,7 @@ def _render_issue_content(
     events_html = "\n".join(events_html_parts)
 
     # Sidebar
-    sidebar = _render_sidebar(contributors, meta, issue, config)
+    sidebar = _render_sidebar(contributors, meta, issue, config, linked=linked)
 
     return f"""\
 <div class="container">
@@ -147,8 +150,11 @@ def _render_issue_content(
   <h1 class="h3">
     <span class="text-light">{html_escape(meta.title)}</span>
     <span class="text-muted fw-thin">#{meta.number}</span>
-    <a target="_blank" rel="noopener" href="https://github.com/{config.owner}/{config.repository}/issues/{meta.number}" class="text-decoration-none fs-4 text-reset">
+    <a target="_blank" rel="noopener" href="https://github.com/{config.owner}/{config.repository}/issues/{meta.number}" class="text-decoration-none fs-4 text-reset" title="View on GitHub">
       {svg_icon(b, "box-arrow-up-right")}
+    </a>
+    <a href="{b}graph/?start={meta.number}" class="text-decoration-none fs-4 text-reset" title="View in graph">
+      {svg_icon(b, "diagram-2")}
     </a>
   </h1>
   <span>
@@ -181,6 +187,7 @@ def _render_pull_content(
     data: dict[str, Any],
     config: Config,
     md: MarkdownRenderer,
+    linked: list[EntryMeta],
 ) -> str:
     """Render PR page content (port of partials/render-pull.html)."""
     b = config.base_url
@@ -249,7 +256,7 @@ def _render_pull_content(
 """
 
     # Sidebar
-    sidebar = _render_sidebar(contributors, meta, pull, config, reviewers_html)
+    sidebar = _render_sidebar(contributors, meta, pull, config, reviewers_html, linked=linked)
 
     # Tabs
     tabs = f"""\
@@ -281,8 +288,11 @@ def _render_pull_content(
   <h1 class="h3">
     <span class="text-light">{html_escape(meta.title)}</span>
     <span class="text-muted fw-thin">#{meta.number}</span>
-    <a href="https://github.com/{config.owner}/{config.repository}/issues/{meta.number}" class="text-decoration-none text-reset fs-4">
+    <a href="https://github.com/{config.owner}/{config.repository}/issues/{meta.number}" class="text-decoration-none text-reset fs-4" title="View on GitHub">
       {svg_icon(b, "box-arrow-up-right")}
+    </a>
+    <a href="{b}graph/?start={meta.number}" class="text-decoration-none text-reset fs-4" title="View in graph">
+      {svg_icon(b, "diagram-2")}
     </a>
   </h1>
   <span>
@@ -318,15 +328,26 @@ def _render_pull_content(
 """
 
 
+def _sidebar_section(title: str, items_html: str) -> str:
+    return (
+        f'<div class="mx-3 mt-2 mb-1">'
+        f'<small class="text-muted">{title}</small>'
+        f'<div class="list-group list-group-flush mt-0">{items_html}</div>'
+        f'</div>'
+    )
+
+
 def _render_sidebar(
     contributors: list[dict[str, Any]],
     meta: EntryMeta,
     item: dict[str, Any],
     config: Config,
     extra_html: str = "",
+    linked: list[EntryMeta] | None = None,
 ) -> str:
-    """Render the right sidebar: contributors, labels, milestone, optional extras."""
+    """Render the right sidebar: contributors, labels, milestone, linked items."""
     b = config.base_url
+    linked = linked or []
 
     # Deduplicate contributors by login
     seen: set[str] = set()
@@ -344,20 +365,21 @@ def _render_sidebar(
         login = c.get("login", "unknown")
         avatar = c.get("avatar_url", "?")
         contrib_parts.append(
-            f'<a href="{b}contributor/{login.lower()}/" class="d-inline-block text-decoration-none text-reset m-1">'
-            f'<img src="{avatar}" class="img-fluid rounded-5" width=24>'
-            f'<span class="text-reset text-decoration-none">{html_escape(login)}</span></a>'
+            f'<a href="{b}contributor/{login.lower()}/" '
+            f'class="list-group-item list-group-item-action border-0 text-decoration-none text-reset d-flex align-items-center gap-2 py-1 px-2">'
+            f'<img src="{avatar}" class="img-fluid rounded-5 flex-shrink-0" width=20>'
+            f'<span>{html_escape(login)}</span></a>'
         )
 
     labels_html = ""
     if meta.labels:
-        labels_html = f"""\
-      <p class="m-3">
-        <span>Labels</span>
-        <br>
-        <span>{issue_labels(meta.labels, b)}</span>
-      </p>
-"""
+        label_items = "".join(
+            f'<a href="{b}labels/{urlize(name)}/" '
+            f'class="list-group-item list-group-item-action border-0 text-decoration-none text-reset py-1 px-2">'
+            f'{render_label(name)}</a>'
+            for name in meta.labels
+        )
+        labels_html = _sidebar_section("Labels", label_items)
 
     milestone_html = ""
     if item.get("milestone"):
@@ -372,15 +394,32 @@ def _render_sidebar(
       </p>
 """
 
+    linked_html = ""
+    if linked:
+        graph_link = (
+            f'<a href="{b}graph/?start={meta.number}" class="text-reset">'
+            f'<small>view graph</small>'
+            f'</a>'
+        )
+        items_html = "".join(
+            f'<a href="{b}{e.number}/" '
+            f'class="list-group-item list-group-item-action border-0 overflow-hidden text-decoration-none text-reset d-flex align-items-center gap-2 py-1 px-2">'
+            f'<span class="flex-shrink-0 badge state-{e.state} state-dot"></span>'
+            f'<span class="text-truncate">'
+            f'<small class="text-muted">#{e.number}</small> {html_escape(e.title)}'
+            f'</span>'
+            f'</a>'
+            for e in linked
+        )
+        linked_html = _sidebar_section(f"Linked ({graph_link})", items_html)
+
+    contributors_html = "".join(contrib_parts)
     return f"""\
-      <p class="m-3">
-        <label>Contributors</label>
-        <br>
-          {"".join(contrib_parts)}
-        </p>
+      {_sidebar_section("Contributors", contributors_html)}
       {extra_html}
       {labels_html}
       {milestone_html}
+      {linked_html}
 """
 
 

--- a/mirror/html/renderer.py
+++ b/mirror/html/renderer.py
@@ -79,10 +79,24 @@ class SiteRenderer:
 
     def _render_entries(self) -> None:
         """Render each issue/PR page. Re-reads full JSON one at a time."""
+        # Build undirected adjacency: number -> set of linked numbers.
+        linked: dict[int, set[int]] = {}
+        for link in self.index.graph.links:
+            src, tgt = link["source"], link["target"]
+            linked.setdefault(src, set()).add(tgt)
+            linked.setdefault(tgt, set()).add(src)
+
         total = len(self.index.entries)
         for i, meta in enumerate(self.index.entries):
             if (i + 1) % 100 == 0 or i == 0 or i == total - 1:
                 print(f"Rendering entries... {i + 1}/{total}", end="\r", flush=True)
+
+            # Resolve linked EntryMeta objects (only those present in the index).
+            linked_entries = sorted(
+                (self.index.by_number[n] for n in linked.get(meta.number, set())
+                 if n in self.index.by_number),
+                key=lambda e: e.number,
+            )
 
             # Re-read full JSON
             data = _read_json(meta.json_path)
@@ -91,7 +105,7 @@ class SiteRenderer:
             if meta.is_pr and "comments" in data:
                 build_pull_timeline(data)
 
-            html = render_entry_page(meta, data, self.config, self.md)
+            html = render_entry_page(meta, data, self.config, self.md, linked_entries)
             self._write(self.config.output_dir / str(meta.number) / "index.html", html)
 
             del data  # Release memory

--- a/mirror/html/templates.py
+++ b/mirror/html/templates.py
@@ -57,6 +57,13 @@ table, td, th {
   padding: 0.4em;
 }
 
+.state-dot {
+  width: 6px;
+  height: 6px;
+  padding: 0;
+  border-radius: 50%;
+}
+
 .state-complete {
   background-color: var(--bs-indigo) !important;
   color: var(--bs-light);
@@ -314,10 +321,48 @@ def search_script(config: Config) -> str:
 
 
 def graph_script(config: Config) -> str:
-    """Return the force-graph JS (port of partials/graph.html)."""
+    """Return the force-graph JS.
+
+    Reads ?start=N from the URL. The graph starts with that node and its
+    immediate neighbours rendered as cards. Clicking a card expands its hidden
+    neighbours; ctrl/cmd-clicking opens the issue/PR page.
+    """
     b = config.base_url
     return f"""\
-<div id="graph-wrapper" class="container">
+<style>
+/* Break out of Bootstrap container so the graph uses the full viewport width. */
+#graph-wrapper {{
+    width: 100vw;
+    position: relative;
+    left: 50%;
+    margin-left: -50vw;
+    height: calc(100vh - 120px);
+    min-height: 400px;
+    background: #0d1117;
+}}
+#graph-controls {{
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    z-index: 10;
+}}
+#graph-hint {{
+    position: absolute;
+    bottom: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10;
+    font-size: 0.78em;
+    color: #555;
+    pointer-events: none;
+}}
+</style>
+
+<div id="graph-wrapper">
+    <div id="graph-controls">
+        <button id="btn-reset" class="btn btn-sm btn-outline-secondary">Reset</button>
+    </div>
+    <span id="graph-hint">click card to open &middot; click &ldquo;Load +N connected&rdquo; to expand</span>
     <div id="graph"></div>
 </div>
 
@@ -326,80 +371,311 @@ def graph_script(config: Config) -> str:
 <script src="//unpkg.com/d3-quadtree"></script>
 
 <script>
-    window.onload = function () {{
-        function nodeColor(n) {{
-            if (n.state == "merged" || n.state == "complete") {{
-                return "#6610f2";
-            }} else if (n.state == "draft") {{
-                return "";
-            }} else if (n.state == "closed") {{
-                return "#6c757d";
-            }} else if (n.state == "open") {{
-                return "#188754";
-            }}
-            return "black";
+window.onload = function () {{
+    const params = new URLSearchParams(window.location.search);
+    const startNum = params.has('start') ? parseInt(params.get('start')) : null;
+
+    if (startNum === null) {{
+        document.getElementById('graph').innerHTML =
+            '<p style="color:#888;padding:2em;">Open this graph from an issue or PR page.</p>';
+        document.getElementById('btn-reset').style.display = 'none';
+        return;
+    }}
+
+    // Card dimensions in graph-space pixels.
+    const CW = 240, CH = 78, CR = 4;
+
+    function stateColor(n) {{
+        if (n.state === "merged" || n.state === "complete") return "#6610f2";
+        if (n.state === "draft") return "#6c757d";
+        if (n.state === "closed") return "#dc3545";
+        if (n.state === "open") return "#188754";
+        return "#444";
+    }}
+
+    // Draw a rounded rectangle path (no fill/stroke — caller decides).
+    function roundRect(ctx, x, y, w, h, r) {{
+        ctx.beginPath();
+        ctx.moveTo(x + r, y);
+        ctx.lineTo(x + w - r, y);
+        ctx.arcTo(x + w, y,     x + w, y + r,     r);
+        ctx.lineTo(x + w, y + h - r);
+        ctx.arcTo(x + w, y + h, x + w - r, y + h, r);
+        ctx.lineTo(x + r, y + h);
+        ctx.arcTo(x,     y + h, x,     y + h - r, r);
+        ctx.lineTo(x,     y + r);
+        ctx.arcTo(x,     y,     x + r, y,          r);
+        ctx.closePath();
+    }}
+
+    // Truncate text to fit maxWidth pixels on the given ctx.
+    function truncate(ctx, text, maxWidth) {{
+        if (ctx.measureText(text).width <= maxWidth) return text;
+        let lo = 0, hi = text.length;
+        while (lo < hi) {{
+            const mid = (lo + hi + 1) >> 1;
+            ctx.measureText(text.slice(0, mid) + '\u2026').width <= maxWidth ? lo = mid : hi = mid - 1;
         }}
+        return text.slice(0, lo) + '\u2026';
+    }}
 
-        function nodeCanvasObject(node, ctx) {{
-            const size = 12;
-            ctx.drawImage(node.img, node.x  - size / 2, node.y - size / 2, size, size);
-
-            ctx.beginPath();
-            if (node.is_pr) {{
-                ctx.arc(node.x, node.y, 7, 0, Math.PI * 2, true);
+    // Word-wrap text into lines, each no wider than maxWidth pixels.
+    function wrapText(ctx, text, maxWidth) {{
+        const words = text.split(' ');
+        const lines = [];
+        let current = '';
+        for (const word of words) {{
+            const test = current ? current + ' ' + word : word;
+            if (current && ctx.measureText(test).width > maxWidth) {{
+                lines.push(current);
+                current = word;
             }} else {{
-                ctx.rect(node.x - 7, node.y - 7, 14, 14);
+                current = test;
             }}
-            ctx.strokeStyle = nodeColor(node);
-            ctx.lineWidth = 3;
-            ctx.stroke();
-
-            ctx.fillStyle = "gray";
-            ctx.font = "12px monospace";
-            ctx.fillText("#" + node.number, node.x + 12, node.y + 4);
         }}
+        if (current) lines.push(current);
+        return lines;
+    }}
 
-        fetch('{b}graph.json')
-            .then((response) => response.json())
-            .then((graph) => {{
+    // Height of the expand-button strip at the bottom of each card.
+    const EXPAND_H = 18;
 
-            graph.nodes.forEach(n => {{
-                const img = new Image();
-                img.src = n.avatar_url;
-                n.img = img;
+    fetch('{b}graph.json')
+        .then(r => r.json())
+        .then(raw => {{
+            // Keep original numeric src/tgt — ForceGraph mutates link objects
+            // during simulation, replacing numbers with node references.
+            const allNodes = raw.nodes;
+            const allLinks = raw.links.map(l => ({{ src: l.source, tgt: l.target }}));
+            const nodeMap = new Map(allNodes.map(n => [n.number, n]));
+
+            // Lazy-load avatar images on first access.
+            const imgs = new Map();
+            function getImg(num, url) {{
+                if (!imgs.has(num)) {{
+                    const img = new Image();
+                    img.src = url;
+                    imgs.set(num, img);
+                }}
+                return imgs.get(num);
+            }}
+
+            // Undirected adjacency map: number -> Set<number>.
+            // Only include links where BOTH endpoints exist in allNodes so we
+            // never add phantom neighbors (cross-refs outside the data set) to
+            // the visible set or pass orphan links to ForceGraph.
+            const adj = new Map();
+            allLinks.forEach(l => {{
+                if (!nodeMap.has(l.src) || !nodeMap.has(l.tgt)) return;
+                if (!adj.has(l.src)) adj.set(l.src, new Set());
+                if (!adj.has(l.tgt)) adj.set(l.tgt, new Set());
+                adj.get(l.src).add(l.tgt);
+                adj.get(l.tgt).add(l.src);
             }});
 
-            let graphWrapper = document.getElementById('graph-wrapper')
+            // Place nums sorted ascending in a circle of given radius around (cx, cy).
+            // Only sets position for nodes that haven't been placed yet.
+            const RING_R = 320;
+            function placeInRing(nums, cx, cy) {{
+                const sorted = [...nums].sort((a, b) => a - b);
+                const count = sorted.length || 1;
+                sorted.forEach((num, i) => {{
+                    const n = nodeMap.get(num);
+                    if (n && n.x == null) {{
+                        const angle = (2 * Math.PI * i) / count - Math.PI / 2;
+                        n.x = cx + RING_R * Math.cos(angle);
+                        n.y = cy + RING_R * Math.sin(angle);
+                    }}
+                }});
+            }}
 
-            const Graph = ForceGraph()
-            (document.getElementById('graph'))
-                .graphData(graph)
+            let visible = new Set();
+
+            function initVisible() {{
+                visible = new Set([startNum]);
+                // Reset all positions so re-init starts fresh.
+                allNodes.forEach(n => {{
+                    delete n.x; delete n.y; delete n.vx; delete n.vy;
+                    delete n.fx; delete n.fy;
+                }});
+                // Pre-position start node at origin.
+                const startNode = nodeMap.get(startNum);
+                if (startNode) {{ startNode.x = 0; startNode.y = 0; }}
+            }}
+            initVisible();
+
+            // Expand hidden neighbours of a node, placing them in a ring around it.
+            function expandNode(node) {{
+                const neighbors = adj.get(node.number) || new Set();
+                const newNums = [...neighbors].filter(n => !visible.has(n));
+                if (newNums.length === 0) return false;
+                newNums.forEach(n => visible.add(n));
+                placeInRing(newNums, node.x ?? 0, node.y ?? 0);
+                return true;
+            }}
+
+            // Fresh node/link arrays for the current visible set. Links are new
+            // objects each call so ForceGraph doesn't see stale mutated references.
+            function getGraphData() {{
+                return {{
+                    nodes: allNodes.filter(n => visible.has(n.number)),
+                    links: allLinks
+                        .filter(l => visible.has(l.src) && visible.has(l.tgt))
+                        .map(l => ({{ source: l.src, target: l.tgt }})),
+                }};
+            }}
+
+            function nodeCanvasObject(node, ctx) {{
+                const x = node.x - CW / 2, y = node.y - CH / 2;
+                const color = stateColor(node);
+                const isStart = node.number === startNum;
+                const neighbors = adj.get(node.number) || new Set();
+                let hiddenCount = 0;
+                for (const n of neighbors) if (!visible.has(n)) hiddenCount++;
+
+                // Card background.
+                roundRect(ctx, x, y, CW, CH, CR);
+                ctx.fillStyle = isStart ? "#2d333b" : "#1c2128";
+                ctx.fill();
+
+                // Outer border — brighter for the start node.
+                roundRect(ctx, x, y, CW, CH, CR);
+                ctx.strokeStyle = isStart ? "#768390" : "#30363d";
+                ctx.lineWidth = isStart ? 2 : 1;
+                ctx.stroke();
+
+                // Left state strip (6px) — plain rect clipped to the card's left rounded corners.
+                ctx.save();
+                roundRect(ctx, x, y, CW, CH, CR);
+                ctx.clip();
+                ctx.fillStyle = color;
+                ctx.fillRect(x, y, 6, CH);
+                ctx.restore();
+
+                const textX = x + 14;
+                const av = 20;
+                const avX = x + CW - av - 8, avY = y + 8;
+
+                // Avatar (clipped circle, top-right).
+                const img = getImg(node.number, node.avatar_url);
+                if (img && img.complete && img.naturalWidth > 0) {{
+                    ctx.save();
+                    ctx.beginPath();
+                    ctx.arc(avX + av / 2, avY + av / 2, av / 2, 0, Math.PI * 2);
+                    ctx.clip();
+                    ctx.drawImage(img, avX, avY, av, av);
+                    ctx.restore();
+                }}
+
+                // State badge (colored pill, left of avatar).
+                const stateLabel = node.state.charAt(0).toUpperCase() + node.state.slice(1);
+                ctx.font = "bold 9px sans-serif";
+                const badgeW = ctx.measureText(stateLabel).width + 10;
+                const badgeX = avX - badgeW - 6, badgeY = avY + 3;
+                roundRect(ctx, badgeX, badgeY, badgeW, 15, 3);
+                ctx.fillStyle = color;
+                ctx.fill();
+                ctx.fillStyle = "#fff";
+                ctx.fillText(stateLabel, badgeX + 5, badgeY + 11);
+
+                // Number row: "#1234  PR/Issue".
+                ctx.font = "bold 11px monospace";
+                ctx.fillStyle = "#8b949e";
+                ctx.fillText("#" + node.number, textX, y + 20);
+                const numW = ctx.measureText("#" + node.number).width;
+                ctx.font = "10px sans-serif";
+                ctx.fillStyle = "#555";
+                ctx.fillText(node.is_pr ? "PR" : "Issue", textX + numW + 5, y + 20);
+
+                // Title — word-wrapped to 2 lines, third line truncated.
+                ctx.font = "11px sans-serif";
+                ctx.fillStyle = "#e6edf3";
+                const titleW = CW - 14 - 8; // strip + margins
+                const lines = wrapText(ctx, node.title, titleW);
+                ctx.fillText(lines[0], textX, y + 38);
+                if (lines.length > 1) {{
+                    const line2 = lines.length > 2
+                        ? truncate(ctx, lines.slice(1).join(' '), titleW)
+                        : lines[1];
+                    ctx.fillText(line2, textX, y + 54);
+                }}
+
+                // Expand button strip along the bottom of the card.
+                if (hiddenCount > 0) {{
+                    const by = y + CH - EXPAND_H;
+                    // Separator line.
+                    ctx.strokeStyle = "#30363d";
+                    ctx.lineWidth = 1;
+                    ctx.beginPath();
+                    ctx.moveTo(x + 6, by);
+                    ctx.lineTo(x + CW, by);
+                    ctx.stroke();
+                    // Strip background on hover hint.
+                    ctx.fillStyle = "#21262d";
+                    ctx.fillRect(x + 6, by, CW - 6, EXPAND_H);
+                    // Label.
+                    ctx.font = "bold 9px sans-serif";
+                    ctx.fillStyle = "#768390";
+                    const label = "Load +" + hiddenCount + " connected";
+                    ctx.fillText(label, x + 14, by + 13);
+                }}
+            }}
+
+            // Hit area matches the card rectangle for accurate hover/click.
+            function nodePointerAreaPaint(node, color, ctx) {{
+                ctx.fillStyle = color;
+                ctx.fillRect(node.x - CW / 2, node.y - CH / 2, CW, CH);
+            }}
+
+            const wrapper = document.getElementById('graph-wrapper');
+            const G = ForceGraph()(document.getElementById('graph'))
+                .graphData(getGraphData())
                 .nodeId('number')
-                .nodeLabel(n => (n.is_pr ? "PR " : "Issue ") +  "#" + n.number + ": " + n.title)
-                .nodeColor(nodeColor)
-                .nodeVal(8)
-                .nodeAutoColorBy("state")
+                .nodeLabel(() => '')
+                .nodeCanvasObject(nodeCanvasObject)
+                .nodeCanvasObjectMode(() => 'replace')
+                .nodePointerAreaPaint(nodePointerAreaPaint)
                 .linkSource('source')
                 .linkTarget('target')
-                .linkColor("#b10c00")
-                .warmupTicks(20)
-                .width(graphWrapper.getBoundingClientRect().width)
-                .height(graphWrapper.getBoundingClientRect().height * 0.8)
-                .d3Force('manybody', d3.forceManyBody().strength(-100))
-                .d3Force('collide', d3.forceCollide(20))
-                .d3Force('x', d3.forceX(0).strength(0.05))
-                .d3Force('y', d3.forceY(0).strength(0.05))
-                .backgroundColor("white")
+                .linkColor(() => "#b10c00")
                 .linkDirectionalArrowLength(6)
                 .linkDirectionalArrowRelPos(0.1)
-                .nodeCanvasObject(nodeCanvasObject)
-                .onNodeDragEnd(node => {{
-                    node.fx = node.x;
-                    node.fy = node.y;
-                }})
-                .onNodeClick(node => window.open(node.url, '_blank').focus())
+                .warmupTicks(40)
+                .width(wrapper.getBoundingClientRect().width)
+                .height(wrapper.getBoundingClientRect().height)
+                // Moderate repulsion — strong enough to separate cards, weak enough
+                // that the link spring can keep connected nodes on screen.
+                .d3Force('manybody', d3.forceManyBody().strength(-400))
+                .d3Force('collide', d3.forceCollide(Math.sqrt((CW / 2) ** 2 + (CH / 2) ** 2) + 20))
+                .d3Force('x', d3.forceX(0).strength(0.05))
+                .d3Force('y', d3.forceY(0).strength(0.05))
+                .backgroundColor("#0d1117")
+                .onNodeDragEnd(node => {{ node.fx = node.x; node.fy = node.y; }})
+                .onNodeClick((node, event) => {{
+                    const neighbors = adj.get(node.number) || new Set();
+                    let hiddenCount = 0;
+                    for (const n of neighbors) if (!visible.has(n)) hiddenCount++;
+
+                    // Convert click position to graph space and check if it landed
+                    // in the expand strip at the bottom of the card.
+                    if (hiddenCount > 0) {{
+                        const gp = G.screen2GraphCoords(event.offsetX, event.offsetY);
+                        const cardBottom = node.y + CH / 2;
+                        if (gp.y >= cardBottom - EXPAND_H) {{
+                            if (expandNode(node)) G.graphData(getGraphData());
+                            return;
+                        }}
+                    }}
+                    // Card body — open the page.
+                    window.open(node.url, '_blank');
+                }});
+
+            document.getElementById('btn-reset').addEventListener('click', () => {{
+                initVisible();
+                G.graphData(getGraphData());
             }});
-    }};
+        }});
+}};
 </script>
 """
 

--- a/mirror/index.py
+++ b/mirror/index.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -18,21 +19,70 @@ def _read_json(path: Path) -> dict[str, Any]:
         return json.load(f)
 
 
+# Bots whose cross-references are noise and should be excluded from the graph.
+_GRAPH_EXCLUDED_ACTORS = frozenset({"drahtbot"})
+
+# Matches any GitHub issue/PR URL: captures (owner, repo, number).
+_RE_GITHUB_URL = re.compile(
+    r"https?://github\.com/([^/\s]+)/([^/\s#]+)/(?:issues|pull)/(\d+)"
+)
+# Matches standalone #NNN references (same-repo convention on GitHub).
+# Applied only after GitHub URLs have been stripped from the body.
+_RE_BODY_REF = re.compile(r"(?<!\w)#(\d+)(?!\d)")
+
+
 def _extract_graph_links(
     data: dict[str, Any], source_number: int, owner_repo: str,
+    body: str | None = None,
 ) -> list[dict[str, int]]:
-    """Extract cross-reference links from events for the graph."""
+    """Extract cross-reference links for the graph.
+
+    Sources:
+    - cross-referenced events (GitHub records these on the *target* when
+      something references it, so they capture incoming links)
+    - same-repo GitHub URLs in the body (cross-referenced events are sometimes
+      absent from backups; URL parsing fills the gap for outgoing links)
+    - plain #NNN references in the body (same-repo convention on GitHub)
+    """
+    seen: set[int] = set()
     links: list[dict[str, int]] = []
+
     for event in data.get("events", []):
         if event.get("event") != "cross-referenced":
             continue
+        actor = (event.get("actor") or {}).get("login", "")
+        if actor.lower() in _GRAPH_EXCLUDED_ACTORS:
+            continue
         source_issue = event.get("source", {}).get("issue", {})
         repo_url = source_issue.get("repository_url", "")
-        if owner_repo in repo_url:
-            links.append({
-                "source": source_number,
-                "target": source_issue["number"],
-            })
+        target = source_issue.get("number")
+        if target and owner_repo in repo_url and target not in seen:
+            seen.add(target)
+            links.append({"source": source_number, "target": target})
+
+    if body:
+        owner_lower, repo_lower = (s.lower() for s in owner_repo.split("/", 1))
+
+        def _on_github_url(m: re.Match) -> str:
+            # Strip every GitHub URL regardless of repo; only record same-repo ones.
+            if m.group(1).lower() == owner_lower and m.group(2).lower() == repo_lower:
+                target = int(m.group(3))
+                if target != source_number and target not in seen:
+                    seen.add(target)
+                    links.append({"source": source_number, "target": target})
+            return ""
+
+        # Pass 1: full GitHub URLs. Strip them all so their numbers are not
+        # picked up by the plain #NNN scan below.
+        cleaned = _RE_GITHUB_URL.sub(_on_github_url, body)
+
+        # Pass 2: plain #NNN references in the URL-stripped body.
+        for m in _RE_BODY_REF.finditer(cleaned):
+            target = int(m.group(1))
+            if target != source_number and target not in seen:
+                seen.add(target)
+                links.append({"source": source_number, "target": target})
+
     return links
 
 
@@ -71,8 +121,9 @@ def build_index(config: Config) -> SiteIndex:
             "is_pr": False,
             "url": f"{config.base_url}{meta.number}/",
         })
+        body = (data.get("issue") or {}).get("body") or ""
         index.graph.links.extend(
-            _extract_graph_links(data, meta.number, owner_repo)
+            _extract_graph_links(data, meta.number, owner_repo, body)
         )
 
         _index_entry(index, meta)
@@ -97,8 +148,9 @@ def build_index(config: Config) -> SiteIndex:
             "is_pr": True,
             "url": f"{config.base_url}{meta.number}/",
         })
+        body = (data.get("pull") or {}).get("body") or ""
         index.graph.links.extend(
-            _extract_graph_links(data, meta.number, owner_repo)
+            _extract_graph_links(data, meta.number, owner_repo, body)
         )
 
         _index_entry(index, meta)
@@ -113,7 +165,9 @@ def build_index(config: Config) -> SiteIndex:
 
 
 def _index_entry(index: SiteIndex, meta: EntryMeta) -> None:
-    """Add an entry to the contributor and label indexes."""
+    """Add an entry to the contributor, label, and number indexes."""
+    index.by_number[meta.number] = meta
+
     login_lower = meta.contributor.lower()
     index.by_contributor.setdefault(login_lower, []).append(meta)
     index.contributor_avatars[login_lower] = meta.avatar_url

--- a/mirror/models.py
+++ b/mirror/models.py
@@ -39,6 +39,7 @@ class SiteIndex:
     """In-memory index built during Pass 1. Used by all renderers."""
 
     entries: list[EntryMeta] = field(default_factory=list)  # sorted by date desc
+    by_number: dict[int, EntryMeta] = field(default_factory=dict)  # number -> entry
     by_contributor: dict[str, list[EntryMeta]] = field(default_factory=dict)  # lowercase login -> entries
     by_label: dict[str, list[EntryMeta]] = field(default_factory=dict)  # label name -> entries
     contributor_avatars: dict[str, str] = field(default_factory=dict)  # lowercase login -> avatar URL

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -11,49 +11,198 @@ from mirror.config import Config
 from mirror.index import build_index, _extract_graph_links
 
 
-class TestExtractGraphLinks(unittest.TestCase):
-    def test_cross_reference_same_repo(self) -> None:
+def _xref_event(number: int, repo_url: str, actor: str | None = None) -> dict:
+    """Build a minimal cross-referenced event."""
+    return {
+        "event": "cross-referenced",
+        "actor": {"login": actor} if actor else None,
+        "source": {
+            "issue": {
+                "number": number,
+                "repository_url": f"https://api.github.com/repos/{repo_url}",
+            }
+        },
+    }
+
+
+class TestExtractGraphLinksEvents(unittest.TestCase):
+    """cross-referenced event handling."""
+
+    def test_same_repo(self) -> None:
+        data = {"events": [_xref_event(99, "owner/repo")]}
+        self.assertEqual(
+            _extract_graph_links(data, 42, "owner/repo"),
+            [{"source": 42, "target": 99}],
+        )
+
+    def test_different_repo_excluded(self) -> None:
+        data = {"events": [_xref_event(99, "other/repo")]}
+        self.assertEqual(_extract_graph_links(data, 42, "owner/repo"), [])
+
+    def test_excluded_bot_actor(self) -> None:
+        data = {"events": [_xref_event(99, "owner/repo", actor="drahtbot")]}
+        self.assertEqual(_extract_graph_links(data, 42, "owner/repo"), [])
+
+    def test_excluded_bot_actor_case_insensitive(self) -> None:
+        data = {"events": [_xref_event(99, "owner/repo", actor="DrahtBot")]}
+        self.assertEqual(_extract_graph_links(data, 42, "owner/repo"), [])
+
+    def test_null_actor_allowed(self) -> None:
+        # actor field can be null in the JSON
+        data = {"events": [_xref_event(99, "owner/repo", actor=None)]}
+        self.assertEqual(
+            _extract_graph_links(data, 42, "owner/repo"),
+            [{"source": 42, "target": 99}],
+        )
+
+    def test_non_cross_reference_events_ignored(self) -> None:
+        data = {"events": [{"event": "labeled", "created_at": "2023-01-01T00:00:00Z"}]}
+        self.assertEqual(_extract_graph_links(data, 42, "owner/repo"), [])
+
+    def test_no_events_key(self) -> None:
+        self.assertEqual(_extract_graph_links({}, 42, "owner/repo"), [])
+
+    def test_multiple_events_deduplication(self) -> None:
+        # Same target appears twice (e.g. two cross-refs) — should produce one link.
         data = {
             "events": [
-                {
-                    "event": "cross-referenced",
-                    "source": {
-                        "issue": {
-                            "number": 99,
-                            "repository_url": "https://api.github.com/repos/owner/repo",
-                        }
-                    },
-                }
+                _xref_event(99, "owner/repo"),
+                _xref_event(99, "owner/repo"),
             ]
         }
         links = _extract_graph_links(data, 42, "owner/repo")
         self.assertEqual(links, [{"source": 42, "target": 99}])
 
-    def test_cross_reference_different_repo(self) -> None:
+    def test_multiple_distinct_events(self) -> None:
         data = {
             "events": [
-                {
-                    "event": "cross-referenced",
-                    "source": {
-                        "issue": {
-                            "number": 99,
-                            "repository_url": "https://api.github.com/repos/other/repo",
-                        }
-                    },
-                }
+                _xref_event(10, "owner/repo"),
+                _xref_event(20, "owner/repo"),
+                _xref_event(30, "other/repo"),   # excluded
             ]
         }
         links = _extract_graph_links(data, 42, "owner/repo")
+        self.assertEqual(links, [
+            {"source": 42, "target": 10},
+            {"source": 42, "target": 20},
+        ])
+
+
+class TestExtractGraphLinksBody(unittest.TestCase):
+    """Body parsing: same-repo GitHub URLs and plain #NNN references."""
+
+    # --- same-repo GitHub URLs ---
+
+    def test_same_repo_issue_url(self) -> None:
+        body = "Fixes https://github.com/owner/repo/issues/100"
+        links = _extract_graph_links({}, 42, "owner/repo", body)
+        self.assertEqual(links, [{"source": 42, "target": 100}])
+
+    def test_same_repo_pull_url(self) -> None:
+        body = "Based on https://github.com/owner/repo/pull/200"
+        links = _extract_graph_links({}, 42, "owner/repo", body)
+        self.assertEqual(links, [{"source": 42, "target": 200}])
+
+    def test_same_repo_url_case_insensitive_owner(self) -> None:
+        # GitHub owner/repo comparisons are case-insensitive.
+        body = "See https://github.com/Owner/Repo/issues/55"
+        links = _extract_graph_links({}, 42, "owner/repo", body)
+        self.assertEqual(links, [{"source": 42, "target": 55}])
+
+    def test_other_repo_url_excluded(self) -> None:
+        body = "See https://github.com/other/repo/issues/99 for background."
+        links = _extract_graph_links({}, 42, "owner/repo", body)
         self.assertEqual(links, [])
 
-    def test_non_cross_reference_events_ignored(self) -> None:
-        data = {"events": [{"event": "labeled", "created_at": "2023-01-01T00:00:00Z"}]}
-        links = _extract_graph_links(data, 42, "owner/repo")
+    def test_other_repo_url_number_not_picked_up_by_hash_regex(self) -> None:
+        # The number inside an other-repo URL must NOT be captured by #NNN scan.
+        # e.g. "github.com/secp256k1/issues/7" — 7 should not become a link.
+        body = "Similar to https://github.com/other/repo/issues/7"
+        links = _extract_graph_links({}, 42, "owner/repo", body)
         self.assertEqual(links, [])
 
-    def test_no_events(self) -> None:
-        links = _extract_graph_links({}, 42, "owner/repo")
+    def test_multiple_same_repo_urls(self) -> None:
+        body = (
+            "This fixes https://github.com/owner/repo/issues/10 "
+            "and https://github.com/owner/repo/pull/20."
+        )
+        links = _extract_graph_links({}, 42, "owner/repo", body)
+        self.assertIn({"source": 42, "target": 10}, links)
+        self.assertIn({"source": 42, "target": 20}, links)
+        self.assertEqual(len(links), 2)
+
+    def test_mixed_repos_in_urls(self) -> None:
+        body = (
+            "Builds on https://github.com/owner/repo/issues/5. "
+            "Related: https://github.com/other/project/issues/999."
+        )
+        links = _extract_graph_links({}, 42, "owner/repo", body)
+        self.assertEqual(links, [{"source": 42, "target": 5}])
+
+    # --- plain #NNN references ---
+
+    def test_plain_hash_ref(self) -> None:
+        body = "This is related to #123."
+        links = _extract_graph_links({}, 42, "owner/repo", body)
+        self.assertEqual(links, [{"source": 42, "target": 123}])
+
+    def test_hash_ref_at_start_of_body(self) -> None:
+        body = "#10 is the predecessor."
+        links = _extract_graph_links({}, 42, "owner/repo", body)
+        self.assertEqual(links, [{"source": 42, "target": 10}])
+
+    def test_hash_ref_self_excluded(self) -> None:
+        # A body mentioning its own number should not create a self-link.
+        body = "This is PR #42 which fixes things."
+        links = _extract_graph_links({}, 42, "owner/repo", body)
         self.assertEqual(links, [])
+
+    def test_hash_ref_inside_word_not_matched(self) -> None:
+        # "issue#42" or "PR#42" should not match — the lookbehind requires non-word char.
+        body = "See issue#42 for context."
+        links = _extract_graph_links({}, 1, "owner/repo", body)
+        self.assertEqual(links, [])
+
+    def test_hash_ref_multiple(self) -> None:
+        body = "Relates to #10, #20, and #30."
+        links = _extract_graph_links({}, 42, "owner/repo", body)
+        targets = {l["target"] for l in links}
+        self.assertEqual(targets, {10, 20, 30})
+
+    def test_hash_ref_deduplicated(self) -> None:
+        body = "See #99 and also #99 again."
+        links = _extract_graph_links({}, 42, "owner/repo", body)
+        self.assertEqual(links, [{"source": 42, "target": 99}])
+
+    def test_no_body(self) -> None:
+        links = _extract_graph_links({}, 42, "owner/repo", None)
+        self.assertEqual(links, [])
+
+    def test_empty_body(self) -> None:
+        links = _extract_graph_links({}, 42, "owner/repo", "")
+        self.assertEqual(links, [])
+
+    # --- interaction between URL pass and #NNN pass ---
+
+    def test_same_repo_url_and_hash_ref_deduplication(self) -> None:
+        # A full URL and a plain #NNN pointing to the same issue should not
+        # produce duplicate links.
+        body = "See https://github.com/owner/repo/issues/77 (i.e. #77)."
+        links = _extract_graph_links({}, 42, "owner/repo", body)
+        self.assertEqual(links, [{"source": 42, "target": 77}])
+
+    def test_event_and_body_deduplication(self) -> None:
+        # cross-referenced event + body mention of the same target → one link.
+        data = {"events": [_xref_event(99, "owner/repo")]}
+        links = _extract_graph_links(data, 42, "owner/repo", body="Also see #99.")
+        self.assertEqual(links, [{"source": 42, "target": 99}])
+
+    def test_event_and_body_combined(self) -> None:
+        # Event brings in 99, body brings in 100 → both present.
+        data = {"events": [_xref_event(99, "owner/repo")]}
+        links = _extract_graph_links(data, 42, "owner/repo", body="#100 is related.")
+        targets = {l["target"] for l in links}
+        self.assertEqual(targets, {99, 100})
 
 
 class TestBuildIndex(unittest.TestCase):


### PR DESCRIPTION
Previously, the graph was essentially broken for large repositories as it would try to load all issues and PRs at the same time. Now, we allow a user to selectivly expand the graph starting from one issue or PR.

Closes #4 

