### PR TITLE
add: user_blocked event support in timeline

### DIFF
--- a/mirror/html/components.py
+++ b/mirror/html/components.py
@@ -372,6 +372,9 @@ def timeline_event(
     if ev == "unlocked":
         return _simple_event(b, "unlock-fill", f"<b>{html_escape(name)}</b> unlocked this {date_str}")
 
+    if ev == "user_blocked":
+        return _simple_event(b, "person-x-fill", f"<b>{html_escape(name)}</b> blocked a user {date_str}")
+
     if ev == "head_ref_deleted":
         return _simple_event(b, "trash-fill", f"<b>{html_escape(name)}</b> deleted the branch {date_str}")
 


### PR DESCRIPTION
fixes #9

was:
<img width="561" height="176" alt="grafik" src="https://github.com/user-attachments/assets/2242191a-7fdf-4d81-86ba-e846d3a06c03" />


now:
<img width="550" height="175" alt="grafik" src="https://github.com/user-attachments/assets/97456084-c707-4088-9327-7f05ac9f7374" />
