### PR TITLE
change: don't preserve permissions duing static copy

### DIFF
--- a/mirror/html/renderer.py
+++ b/mirror/html/renderer.py
@@ -63,13 +63,13 @@ class SiteRenderer:
             if src.is_dir():
                 if dst.exists():
                     shutil.rmtree(dst)
-                shutil.copytree(src, dst)
+                shutil.copytree(src, dst, copy_function=shutil.copy)
 
         # Copy root-level static files
         for name in ("site.webmanifest", "browserconfig.xml"):
             src = static_src / name
             if src.is_file():
-                shutil.copy2(src, out / name)
+                shutil.copy(src, out / name)
 
     def _render_home(self) -> None:
         print("Rendering home page...")


### PR DESCRIPTION
By default this would use copy2, and copy2 preserves file metadata (modification times, permissions), while `copy` only copies the content and basic permissions. We don't need to preserve the static file permissions.

This resolves a build failure in https://github.com/0xB10C/nix/pull/340