### PR TITLE
fix: order of contributor PRs and Issues

### DIFF
--- a/mirror/index.py
+++ b/mirror/index.py
@@ -160,6 +160,10 @@ def build_index(config: Config) -> SiteIndex:
 
     # Sort entries by date descending
     index.entries.sort(key=lambda e: e.date, reverse=True)
+    for entries in index.by_contributor.values():
+        entries.sort(key=lambda e: e.date, reverse=True)
+    for entries in index.by_label.values():
+        entries.sort(key=lambda e: e.date, reverse=True)
 
     return index
 


### PR DESCRIPTION
Previously, the oldest issues were shown first. Now, the newest are at the top.